### PR TITLE
Add DTOs, service layer, and basic CRUD endpoints for library resources

### DIFF
--- a/src/main/java/com/github/nanachi357/library/controller/AuthorController.java
+++ b/src/main/java/com/github/nanachi357/library/controller/AuthorController.java
@@ -1,33 +1,55 @@
 package com.github.nanachi357.library.controller;
 
-import com.github.nanachi357.library.entity.Author;
-import com.github.nanachi357.library.repository.AuthorRepository;
+import com.github.nanachi357.library.dto.AuthorResponse;
+import com.github.nanachi357.library.dto.CreateAuthorRequest;
+import com.github.nanachi357.library.service.AuthorService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
 @RestController
 @RequestMapping("/authors")
+@RequiredArgsConstructor
 public class AuthorController {
 
-    private final AuthorRepository authorRepository;
-
-    public AuthorController(AuthorRepository authorRepository) {
-        this.authorRepository = authorRepository;
-    }
+    private final AuthorService authorService;
 
     @GetMapping
-    public List<Author> getAll() { return authorRepository.findAll(); }
+    public List<AuthorResponse> getAll() {
+        return authorService.getAll();
+    }
 
     @GetMapping("/{id}")
-    public ResponseEntity<Author> getById(@PathVariable Long id) {
-        return authorRepository.findById(id)
+    public ResponseEntity<AuthorResponse> getById(@PathVariable Long id) {
+        return authorService.getById(id)
                 .map(ResponseEntity::ok)
                 .orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public AuthorResponse create(@Valid @RequestBody CreateAuthorRequest request) {
+        return authorService.create(request);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Long id) {
+        if (authorService.deleteById(id)) {
+            return ResponseEntity.noContent().build();
+        }
+
+        return ResponseEntity.notFound().build();
     }
 
 }

--- a/src/main/java/com/github/nanachi357/library/controller/BookController.java
+++ b/src/main/java/com/github/nanachi357/library/controller/BookController.java
@@ -1,35 +1,55 @@
 package com.github.nanachi357.library.controller;
 
-import com.github.nanachi357.library.entity.Book;
-import com.github.nanachi357.library.repository.BookRepository;
+import com.github.nanachi357.library.dto.BookResponse;
+import com.github.nanachi357.library.dto.CreateBookRequest;
+import com.github.nanachi357.library.service.BookService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
 @RestController
 @RequestMapping("/books")
+@RequiredArgsConstructor
 public class BookController {
 
-    private final BookRepository bookRepository;
-
-    public BookController(BookRepository bookRepository) {
-        this.bookRepository = bookRepository;
-    }
+    private final BookService bookService;
 
     @GetMapping
-    public List<Book> getAll() {
-        return bookRepository.findAll();
+    public List<BookResponse> getAll() {
+        return bookService.getAll();
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<Book> getById(@PathVariable Long id) {
-        return bookRepository.findById(id)
+    public ResponseEntity<BookResponse> getById(@PathVariable Long id) {
+        return bookService.getById(id)
                 .map(ResponseEntity::ok)
                 .orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public BookResponse create(@Valid @RequestBody CreateBookRequest request) {
+        return bookService.create(request);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Long id) {
+        if (bookService.deleteById(id)) {
+            return ResponseEntity.noContent().build();
+        }
+
+        return ResponseEntity.notFound().build();
     }
 
 }

--- a/src/main/java/com/github/nanachi357/library/controller/ReaderController.java
+++ b/src/main/java/com/github/nanachi357/library/controller/ReaderController.java
@@ -1,35 +1,55 @@
 package com.github.nanachi357.library.controller;
 
-import com.github.nanachi357.library.entity.Reader;
-import com.github.nanachi357.library.repository.ReaderRepository;
+import com.github.nanachi357.library.dto.CreateReaderRequest;
+import com.github.nanachi357.library.dto.ReaderResponse;
+import com.github.nanachi357.library.service.ReaderService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
 @RestController
 @RequestMapping("/readers")
+@RequiredArgsConstructor
 public class ReaderController {
 
-    private final ReaderRepository readerRepository;
-
-    public ReaderController(ReaderRepository readerRepository) {
-        this.readerRepository = readerRepository;
-    }
+    private final ReaderService readerService;
 
     @GetMapping
-    public List<Reader> getAll() {
-        return readerRepository.findAll();
+    public List<ReaderResponse> getAll() {
+        return readerService.getAll();
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<Reader> getById(@PathVariable Long id) {
-        return readerRepository.findById(id)
+    public ResponseEntity<ReaderResponse> getById(@PathVariable Long id) {
+        return readerService.getById(id)
                 .map(ResponseEntity::ok)
                 .orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public ReaderResponse create(@Valid @RequestBody CreateReaderRequest request) {
+        return readerService.create(request);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Long id) {
+        if (readerService.deleteById(id)) {
+            return ResponseEntity.noContent().build();
+        }
+
+        return ResponseEntity.notFound().build();
     }
 
 }

--- a/src/main/java/com/github/nanachi357/library/dto/AuthorResponse.java
+++ b/src/main/java/com/github/nanachi357/library/dto/AuthorResponse.java
@@ -1,0 +1,11 @@
+package com.github.nanachi357.library.dto;
+
+import java.time.LocalDate;
+
+public record AuthorResponse(
+        Long id,
+        String name,
+        LocalDate birthDate,
+        String country
+) {
+}

--- a/src/main/java/com/github/nanachi357/library/dto/BookResponse.java
+++ b/src/main/java/com/github/nanachi357/library/dto/BookResponse.java
@@ -1,0 +1,7 @@
+package com.github.nanachi357.library.dto;
+
+public record BookResponse(
+        Long id,
+        String title
+) {
+}

--- a/src/main/java/com/github/nanachi357/library/dto/CreateAuthorRequest.java
+++ b/src/main/java/com/github/nanachi357/library/dto/CreateAuthorRequest.java
@@ -1,0 +1,23 @@
+package com.github.nanachi357.library.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PastOrPresent;
+import jakarta.validation.constraints.Pattern;
+
+import java.time.LocalDate;
+
+public record CreateAuthorRequest(
+        @NotBlank
+        @Pattern(regexp = "^[^0-9]*$")
+        String name,
+
+        @NotNull
+        @PastOrPresent
+        LocalDate birthDate,
+
+        @NotBlank
+        @Pattern(regexp = "^[^0-9]*$")
+        String country
+) {
+}

--- a/src/main/java/com/github/nanachi357/library/dto/CreateBookRequest.java
+++ b/src/main/java/com/github/nanachi357/library/dto/CreateBookRequest.java
@@ -1,0 +1,9 @@
+package com.github.nanachi357.library.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record CreateBookRequest(
+        @NotBlank
+        String title
+) {
+}

--- a/src/main/java/com/github/nanachi357/library/dto/CreateReaderRequest.java
+++ b/src/main/java/com/github/nanachi357/library/dto/CreateReaderRequest.java
@@ -1,0 +1,11 @@
+package com.github.nanachi357.library.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record CreateReaderRequest(
+        @NotBlank
+        @Pattern(regexp = "^[^0-9]*$")
+        String name
+) {
+}

--- a/src/main/java/com/github/nanachi357/library/dto/ReaderResponse.java
+++ b/src/main/java/com/github/nanachi357/library/dto/ReaderResponse.java
@@ -1,0 +1,7 @@
+package com.github.nanachi357.library.dto;
+
+public record ReaderResponse(
+        Long id,
+        String name
+) {
+}

--- a/src/main/java/com/github/nanachi357/library/entity/Author.java
+++ b/src/main/java/com/github/nanachi357/library/entity/Author.java
@@ -1,13 +1,13 @@
 package com.github.nanachi357.library.entity;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
+import lombok.Data;
 
 import java.time.LocalDate;
 
+@Data
 @Entity
+@Table(name = "authors")
 public class Author {
 
     @Id
@@ -26,34 +26,6 @@ public class Author {
     public Author(String name, LocalDate birthDate, String country) {
         this.name = name;
         this.birthDate = birthDate;
-        this.country = country;
-    }
-
-    public Long getId() {
-        return id;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    public LocalDate getBirthDate() {
-        return birthDate;
-    }
-
-    public void setBirthDate(LocalDate birthDate) {
-        this.birthDate = birthDate;
-    }
-
-    public String getCountry() {
-        return country;
-    }
-
-    public void setCountry(String country) {
         this.country = country;
     }
 

--- a/src/main/java/com/github/nanachi357/library/entity/Book.java
+++ b/src/main/java/com/github/nanachi357/library/entity/Book.java
@@ -1,11 +1,11 @@
 package com.github.nanachi357.library.entity;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
+import lombok.Data;
 
+@Data
 @Entity
+@Table(name = "books")
 public class Book {
 
     @Id
@@ -18,18 +18,6 @@ public class Book {
     }
 
     public Book(String title) {
-        this.title = title;
-    }
-
-    public Long getId() {
-        return id;
-    }
-
-    public String getTitle() {
-        return title;
-    }
-
-    public void setTitle(String title) {
         this.title = title;
     }
 

--- a/src/main/java/com/github/nanachi357/library/entity/Reader.java
+++ b/src/main/java/com/github/nanachi357/library/entity/Reader.java
@@ -1,11 +1,11 @@
 package com.github.nanachi357.library.entity;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
+import lombok.Data;
 
+@Data
 @Entity
+@Table(name = "readers")
 public class Reader {
 
     @Id
@@ -18,18 +18,6 @@ public class Reader {
     }
 
     public Reader(String name) {
-        this.name = name;
-    }
-
-    public Long getId() {
-        return id;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
         this.name = name;
     }
 

--- a/src/main/java/com/github/nanachi357/library/service/AuthorService.java
+++ b/src/main/java/com/github/nanachi357/library/service/AuthorService.java
@@ -1,0 +1,55 @@
+package com.github.nanachi357.library.service;
+
+import com.github.nanachi357.library.dto.AuthorResponse;
+import com.github.nanachi357.library.dto.CreateAuthorRequest;
+import com.github.nanachi357.library.entity.Author;
+import com.github.nanachi357.library.repository.AuthorRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class AuthorService {
+
+    private final AuthorRepository authorRepository;
+
+    public List<AuthorResponse> getAll() {
+        return authorRepository.findAll().stream()
+                .map(this::toResponse)
+                .toList();
+    }
+
+    public Optional<AuthorResponse> getById(Long id) {
+        return authorRepository.findById(id)
+                .map(this::toResponse);
+    }
+
+    public AuthorResponse create(CreateAuthorRequest request) {
+        Author author = new Author(request.name(), request.birthDate(), request.country());
+        Author savedAuthor = authorRepository.save(author);
+
+        return toResponse(savedAuthor);
+    }
+
+    public boolean deleteById(Long id) {
+        if (!authorRepository.existsById(id)) {
+            return false;
+        }
+
+        authorRepository.deleteById(id);
+        return true;
+    }
+
+    private AuthorResponse toResponse(Author author) {
+        return new AuthorResponse(
+                author.getId(),
+                author.getName(),
+                author.getBirthDate(),
+                author.getCountry()
+        );
+    }
+
+}

--- a/src/main/java/com/github/nanachi357/library/service/BookService.java
+++ b/src/main/java/com/github/nanachi357/library/service/BookService.java
@@ -1,0 +1,53 @@
+package com.github.nanachi357.library.service;
+
+import com.github.nanachi357.library.dto.BookResponse;
+import com.github.nanachi357.library.dto.CreateBookRequest;
+import com.github.nanachi357.library.entity.Book;
+import com.github.nanachi357.library.repository.BookRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class BookService {
+
+    private final BookRepository bookRepository;
+
+    public List<BookResponse> getAll() {
+        return bookRepository.findAll().stream()
+                .map(this::toResponse)
+                .toList();
+    }
+
+    public Optional<BookResponse> getById(Long id) {
+        return bookRepository.findById(id)
+                .map(this::toResponse);
+    }
+
+    public BookResponse create(CreateBookRequest request) {
+        Book book = new Book(request.title());
+        Book savedBook = bookRepository.save(book);
+
+        return toResponse(savedBook);
+    }
+
+    public boolean deleteById(Long id) {
+        if (!bookRepository.existsById(id)) {
+            return false;
+        }
+
+        bookRepository.deleteById(id);
+        return true;
+    }
+
+    private BookResponse toResponse(Book book) {
+        return new BookResponse(
+                book.getId(),
+                book.getTitle()
+        );
+    }
+
+}

--- a/src/main/java/com/github/nanachi357/library/service/ReaderService.java
+++ b/src/main/java/com/github/nanachi357/library/service/ReaderService.java
@@ -1,0 +1,53 @@
+package com.github.nanachi357.library.service;
+
+import com.github.nanachi357.library.dto.CreateReaderRequest;
+import com.github.nanachi357.library.dto.ReaderResponse;
+import com.github.nanachi357.library.entity.Reader;
+import com.github.nanachi357.library.repository.ReaderRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class ReaderService {
+
+    private final ReaderRepository readerRepository;
+
+    public List<ReaderResponse> getAll() {
+        return readerRepository.findAll().stream()
+                .map(this::toResponse)
+                .toList();
+    }
+
+    public Optional<ReaderResponse> getById(Long id) {
+        return readerRepository.findById(id)
+                .map(this::toResponse);
+    }
+
+    public ReaderResponse create(CreateReaderRequest request) {
+        Reader reader = new Reader(request.name());
+        Reader savedReader = readerRepository.save(reader);
+
+        return toResponse(savedReader);
+    }
+
+    public boolean deleteById(Long id) {
+        if (!readerRepository.existsById(id)) {
+            return false;
+        }
+
+        readerRepository.deleteById(id);
+        return true;
+    }
+
+    private ReaderResponse toResponse(Reader reader) {
+        return new ReaderResponse(
+                reader.getId(),
+                reader.getName()
+        );
+    }
+
+}


### PR DESCRIPTION
## Summary

This PR adds a consistent API structure for the main library resources:
- Author
- Book
- Reader

## Changes
- added request/response DTOs
- added service layer between controllers and repositories
- added `POST` and `DELETE` endpoints
- moved existing `GET` endpoints to `Controller -> Service -> Repository`

## Endpoints
- `GET /authors`, `GET /authors/{id}`, `POST /authors`, `DELETE /authors/{id}`
- `GET /books`, `GET /books/{id}`, `POST /books`, `DELETE /books/{id}`
- `GET /readers`, `GET /readers/{id}`, `POST /readers`, `DELETE /readers/{id}`

## Validation
- required fields must not be blank/null
- author birth date must not be in the future
- reader name and author name/country must not contain digits

## Verification
- project compiles
- application starts successfully
- create/get/delete flows verified for Author, Book, and Reader