### PR TITLE
Add PUT and PATCH endpoints for library resources

### DIFF
--- a/src/main/java/com/github/nanachi357/library/controller/AuthorController.java
+++ b/src/main/java/com/github/nanachi357/library/controller/AuthorController.java
@@ -2,15 +2,19 @@ package com.github.nanachi357.library.controller;
 
 import com.github.nanachi357.library.dto.AuthorResponse;
 import com.github.nanachi357.library.dto.CreateAuthorRequest;
+import com.github.nanachi357.library.dto.PatchAuthorRequest;
+import com.github.nanachi357.library.dto.UpdateAuthorRequest;
 import com.github.nanachi357.library.service.AuthorService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -41,6 +45,26 @@ public class AuthorController {
     @ResponseStatus(HttpStatus.CREATED)
     public AuthorResponse create(@Valid @RequestBody CreateAuthorRequest request) {
         return authorService.create(request);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<AuthorResponse> update(
+            @PathVariable Long id,
+            @Valid @RequestBody UpdateAuthorRequest request
+    ) {
+        return authorService.update(id, request)
+                .map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @PatchMapping("/{id}")
+    public ResponseEntity<AuthorResponse> patch(
+            @PathVariable Long id,
+            @Valid @RequestBody PatchAuthorRequest request
+    ) {
+        return authorService.patch(id, request)
+                .map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.notFound().build());
     }
 
     @DeleteMapping("/{id}")

--- a/src/main/java/com/github/nanachi357/library/controller/AuthorController.java
+++ b/src/main/java/com/github/nanachi357/library/controller/AuthorController.java
@@ -52,9 +52,13 @@ public class AuthorController {
             @PathVariable Long id,
             @Valid @RequestBody UpdateAuthorRequest request
     ) {
-        return authorService.update(id, request)
-                .map(ResponseEntity::ok)
-                .orElseGet(() -> ResponseEntity.notFound().build());
+        var response = authorService.update(id, request);
+
+        if (response.isEmpty()) {
+            return ResponseEntity.notFound().build();
+        }
+
+        return ResponseEntity.ok(response.get());
     }
 
     @PatchMapping("/{id}")
@@ -62,9 +66,13 @@ public class AuthorController {
             @PathVariable Long id,
             @Valid @RequestBody PatchAuthorRequest request
     ) {
-        return authorService.patch(id, request)
-                .map(ResponseEntity::ok)
-                .orElseGet(() -> ResponseEntity.notFound().build());
+        var response = authorService.patch(id, request);
+
+        if (response.isEmpty()) {
+            return ResponseEntity.notFound().build();
+        }
+
+        return ResponseEntity.ok(response.get());
     }
 
     @DeleteMapping("/{id}")

--- a/src/main/java/com/github/nanachi357/library/controller/BookController.java
+++ b/src/main/java/com/github/nanachi357/library/controller/BookController.java
@@ -2,15 +2,19 @@ package com.github.nanachi357.library.controller;
 
 import com.github.nanachi357.library.dto.BookResponse;
 import com.github.nanachi357.library.dto.CreateBookRequest;
+import com.github.nanachi357.library.dto.PatchBookRequest;
+import com.github.nanachi357.library.dto.UpdateBookRequest;
 import com.github.nanachi357.library.service.BookService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -41,6 +45,26 @@ public class BookController {
     @ResponseStatus(HttpStatus.CREATED)
     public BookResponse create(@Valid @RequestBody CreateBookRequest request) {
         return bookService.create(request);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<BookResponse> update(
+            @PathVariable Long id,
+            @Valid @RequestBody UpdateBookRequest request
+    ) {
+        return bookService.update(id, request)
+                .map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @PatchMapping("/{id}")
+    public ResponseEntity<BookResponse> patch(
+            @PathVariable Long id,
+            @Valid @RequestBody PatchBookRequest request
+    ) {
+        return bookService.patch(id, request)
+                .map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.notFound().build());
     }
 
     @DeleteMapping("/{id}")

--- a/src/main/java/com/github/nanachi357/library/controller/BookController.java
+++ b/src/main/java/com/github/nanachi357/library/controller/BookController.java
@@ -52,9 +52,13 @@ public class BookController {
             @PathVariable Long id,
             @Valid @RequestBody UpdateBookRequest request
     ) {
-        return bookService.update(id, request)
-                .map(ResponseEntity::ok)
-                .orElseGet(() -> ResponseEntity.notFound().build());
+        var response = bookService.update(id, request);
+
+        if (response.isEmpty()) {
+            return ResponseEntity.notFound().build();
+        }
+
+        return ResponseEntity.ok(response.get());
     }
 
     @PatchMapping("/{id}")
@@ -62,9 +66,13 @@ public class BookController {
             @PathVariable Long id,
             @Valid @RequestBody PatchBookRequest request
     ) {
-        return bookService.patch(id, request)
-                .map(ResponseEntity::ok)
-                .orElseGet(() -> ResponseEntity.notFound().build());
+        var response = bookService.patch(id, request);
+
+        if (response.isEmpty()) {
+            return ResponseEntity.notFound().build();
+        }
+
+        return ResponseEntity.ok(response.get());
     }
 
     @DeleteMapping("/{id}")

--- a/src/main/java/com/github/nanachi357/library/controller/ReaderController.java
+++ b/src/main/java/com/github/nanachi357/library/controller/ReaderController.java
@@ -52,9 +52,13 @@ public class ReaderController {
             @PathVariable Long id,
             @Valid @RequestBody UpdateReaderRequest request
     ) {
-        return readerService.update(id, request)
-                .map(ResponseEntity::ok)
-                .orElseGet(() -> ResponseEntity.notFound().build());
+        var response = readerService.update(id, request);
+
+        if (response.isEmpty()) {
+            return ResponseEntity.notFound().build();
+        }
+
+        return ResponseEntity.ok(response.get());
     }
 
     @PatchMapping("/{id}")
@@ -62,9 +66,13 @@ public class ReaderController {
             @PathVariable Long id,
             @Valid @RequestBody PatchReaderRequest request
     ) {
-        return readerService.patch(id, request)
-                .map(ResponseEntity::ok)
-                .orElseGet(() -> ResponseEntity.notFound().build());
+        var response = readerService.patch(id, request);
+
+        if (response.isEmpty()) {
+            return ResponseEntity.notFound().build();
+        }
+
+        return ResponseEntity.ok(response.get());
     }
 
     @DeleteMapping("/{id}")

--- a/src/main/java/com/github/nanachi357/library/controller/ReaderController.java
+++ b/src/main/java/com/github/nanachi357/library/controller/ReaderController.java
@@ -1,16 +1,20 @@
 package com.github.nanachi357.library.controller;
 
 import com.github.nanachi357.library.dto.CreateReaderRequest;
+import com.github.nanachi357.library.dto.PatchReaderRequest;
 import com.github.nanachi357.library.dto.ReaderResponse;
+import com.github.nanachi357.library.dto.UpdateReaderRequest;
 import com.github.nanachi357.library.service.ReaderService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -41,6 +45,26 @@ public class ReaderController {
     @ResponseStatus(HttpStatus.CREATED)
     public ReaderResponse create(@Valid @RequestBody CreateReaderRequest request) {
         return readerService.create(request);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<ReaderResponse> update(
+            @PathVariable Long id,
+            @Valid @RequestBody UpdateReaderRequest request
+    ) {
+        return readerService.update(id, request)
+                .map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @PatchMapping("/{id}")
+    public ResponseEntity<ReaderResponse> patch(
+            @PathVariable Long id,
+            @Valid @RequestBody PatchReaderRequest request
+    ) {
+        return readerService.patch(id, request)
+                .map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.notFound().build());
     }
 
     @DeleteMapping("/{id}")

--- a/src/main/java/com/github/nanachi357/library/dto/PatchAuthorRequest.java
+++ b/src/main/java/com/github/nanachi357/library/dto/PatchAuthorRequest.java
@@ -1,0 +1,18 @@
+package com.github.nanachi357.library.dto;
+
+import jakarta.validation.constraints.PastOrPresent;
+import jakarta.validation.constraints.Pattern;
+
+import java.time.LocalDate;
+
+public record PatchAuthorRequest(
+        @Pattern(regexp = "^(?=.*\\S)[^0-9]*$")
+        String name,
+
+        @PastOrPresent
+        LocalDate birthDate,
+
+        @Pattern(regexp = "^(?=.*\\S)[^0-9]*$")
+        String country
+) {
+}

--- a/src/main/java/com/github/nanachi357/library/dto/PatchBookRequest.java
+++ b/src/main/java/com/github/nanachi357/library/dto/PatchBookRequest.java
@@ -1,0 +1,9 @@
+package com.github.nanachi357.library.dto;
+
+import jakarta.validation.constraints.Pattern;
+
+public record PatchBookRequest(
+        @Pattern(regexp = ".*\\S.*")
+        String title
+) {
+}

--- a/src/main/java/com/github/nanachi357/library/dto/PatchReaderRequest.java
+++ b/src/main/java/com/github/nanachi357/library/dto/PatchReaderRequest.java
@@ -1,0 +1,9 @@
+package com.github.nanachi357.library.dto;
+
+import jakarta.validation.constraints.Pattern;
+
+public record PatchReaderRequest(
+        @Pattern(regexp = "^(?=.*\\S)[^0-9]*$")
+        String name
+) {
+}

--- a/src/main/java/com/github/nanachi357/library/dto/UpdateAuthorRequest.java
+++ b/src/main/java/com/github/nanachi357/library/dto/UpdateAuthorRequest.java
@@ -1,0 +1,23 @@
+package com.github.nanachi357.library.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PastOrPresent;
+import jakarta.validation.constraints.Pattern;
+
+import java.time.LocalDate;
+
+public record UpdateAuthorRequest(
+        @NotBlank
+        @Pattern(regexp = "^[^0-9]*$")
+        String name,
+
+        @NotNull
+        @PastOrPresent
+        LocalDate birthDate,
+
+        @NotBlank
+        @Pattern(regexp = "^[^0-9]*$")
+        String country
+) {
+}

--- a/src/main/java/com/github/nanachi357/library/dto/UpdateBookRequest.java
+++ b/src/main/java/com/github/nanachi357/library/dto/UpdateBookRequest.java
@@ -1,0 +1,9 @@
+package com.github.nanachi357.library.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record UpdateBookRequest(
+        @NotBlank
+        String title
+) {
+}

--- a/src/main/java/com/github/nanachi357/library/dto/UpdateReaderRequest.java
+++ b/src/main/java/com/github/nanachi357/library/dto/UpdateReaderRequest.java
@@ -1,0 +1,11 @@
+package com.github.nanachi357.library.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record UpdateReaderRequest(
+        @NotBlank
+        @Pattern(regexp = "^[^0-9]*$")
+        String name
+) {
+}

--- a/src/main/java/com/github/nanachi357/library/mapper/AuthorMapper.java
+++ b/src/main/java/com/github/nanachi357/library/mapper/AuthorMapper.java
@@ -1,10 +1,15 @@
 package com.github.nanachi357.library.mapper;
 
+import com.github.nanachi357.library.dto.PatchAuthorRequest;
 import com.github.nanachi357.library.dto.AuthorResponse;
 import com.github.nanachi357.library.dto.CreateAuthorRequest;
+import com.github.nanachi357.library.dto.UpdateAuthorRequest;
 import com.github.nanachi357.library.entity.Author;
+import org.mapstruct.BeanMapping;
 import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
 import org.mapstruct.Mapper;
+import org.mapstruct.NullValuePropertyMappingStrategy;
 
 @Mapper(componentModel = "spring")
 public interface AuthorMapper {
@@ -13,5 +18,12 @@ public interface AuthorMapper {
 
     @Mapping(target = "id", ignore = true)
     Author toEntity(CreateAuthorRequest request);
+
+    @Mapping(target = "id", ignore = true)
+    void updateEntity(UpdateAuthorRequest request, @MappingTarget Author author);
+
+    @Mapping(target = "id", ignore = true)
+    @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
+    void patchEntity(PatchAuthorRequest request, @MappingTarget Author author);
 
 }

--- a/src/main/java/com/github/nanachi357/library/mapper/BookMapper.java
+++ b/src/main/java/com/github/nanachi357/library/mapper/BookMapper.java
@@ -1,10 +1,15 @@
 package com.github.nanachi357.library.mapper;
 
+import com.github.nanachi357.library.dto.PatchBookRequest;
 import com.github.nanachi357.library.dto.BookResponse;
 import com.github.nanachi357.library.dto.CreateBookRequest;
+import com.github.nanachi357.library.dto.UpdateBookRequest;
 import com.github.nanachi357.library.entity.Book;
+import org.mapstruct.BeanMapping;
 import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
 import org.mapstruct.Mapper;
+import org.mapstruct.NullValuePropertyMappingStrategy;
 
 @Mapper(componentModel = "spring")
 public interface BookMapper {
@@ -13,5 +18,12 @@ public interface BookMapper {
 
     @Mapping(target = "id", ignore = true)
     Book toEntity(CreateBookRequest request);
+
+    @Mapping(target = "id", ignore = true)
+    void updateEntity(UpdateBookRequest request, @MappingTarget Book book);
+
+    @Mapping(target = "id", ignore = true)
+    @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
+    void patchEntity(PatchBookRequest request, @MappingTarget Book book);
 
 }

--- a/src/main/java/com/github/nanachi357/library/mapper/ReaderMapper.java
+++ b/src/main/java/com/github/nanachi357/library/mapper/ReaderMapper.java
@@ -1,10 +1,15 @@
 package com.github.nanachi357.library.mapper;
 
 import com.github.nanachi357.library.dto.CreateReaderRequest;
+import com.github.nanachi357.library.dto.PatchReaderRequest;
 import com.github.nanachi357.library.dto.ReaderResponse;
+import com.github.nanachi357.library.dto.UpdateReaderRequest;
 import com.github.nanachi357.library.entity.Reader;
+import org.mapstruct.BeanMapping;
 import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
 import org.mapstruct.Mapper;
+import org.mapstruct.NullValuePropertyMappingStrategy;
 
 @Mapper(componentModel = "spring")
 public interface ReaderMapper {
@@ -13,5 +18,12 @@ public interface ReaderMapper {
 
     @Mapping(target = "id", ignore = true)
     Reader toEntity(CreateReaderRequest request);
+
+    @Mapping(target = "id", ignore = true)
+    void updateEntity(UpdateReaderRequest request, @MappingTarget Reader reader);
+
+    @Mapping(target = "id", ignore = true)
+    @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
+    void patchEntity(PatchReaderRequest request, @MappingTarget Reader reader);
 
 }

--- a/src/main/java/com/github/nanachi357/library/service/AuthorService.java
+++ b/src/main/java/com/github/nanachi357/library/service/AuthorService.java
@@ -2,11 +2,14 @@ package com.github.nanachi357.library.service;
 
 import com.github.nanachi357.library.dto.AuthorResponse;
 import com.github.nanachi357.library.dto.CreateAuthorRequest;
+import com.github.nanachi357.library.dto.PatchAuthorRequest;
+import com.github.nanachi357.library.dto.UpdateAuthorRequest;
 import com.github.nanachi357.library.entity.Author;
 import com.github.nanachi357.library.mapper.AuthorMapper;
 import com.github.nanachi357.library.repository.AuthorRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
@@ -34,6 +37,24 @@ public class AuthorService {
         Author savedAuthor = authorRepository.save(author);
 
         return authorMapper.toResponse(savedAuthor);
+    }
+
+    @Transactional
+    public Optional<AuthorResponse> update(Long id, UpdateAuthorRequest request) {
+        return authorRepository.findById(id)
+                .map(author -> {
+                    authorMapper.updateEntity(request, author);
+                    return authorMapper.toResponse(author);
+                });
+    }
+
+    @Transactional
+    public Optional<AuthorResponse> patch(Long id, PatchAuthorRequest request) {
+        return authorRepository.findById(id)
+                .map(author -> {
+                    authorMapper.patchEntity(request, author);
+                    return authorMapper.toResponse(author);
+                });
     }
 
     public boolean deleteById(Long id) {

--- a/src/main/java/com/github/nanachi357/library/service/BookService.java
+++ b/src/main/java/com/github/nanachi357/library/service/BookService.java
@@ -2,11 +2,14 @@ package com.github.nanachi357.library.service;
 
 import com.github.nanachi357.library.dto.BookResponse;
 import com.github.nanachi357.library.dto.CreateBookRequest;
+import com.github.nanachi357.library.dto.PatchBookRequest;
+import com.github.nanachi357.library.dto.UpdateBookRequest;
 import com.github.nanachi357.library.entity.Book;
 import com.github.nanachi357.library.mapper.BookMapper;
 import com.github.nanachi357.library.repository.BookRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
@@ -34,6 +37,24 @@ public class BookService {
         Book savedBook = bookRepository.save(book);
 
         return bookMapper.toResponse(savedBook);
+    }
+
+    @Transactional
+    public Optional<BookResponse> update(Long id, UpdateBookRequest request) {
+        return bookRepository.findById(id)
+                .map(book -> {
+                    bookMapper.updateEntity(request, book);
+                    return bookMapper.toResponse(book);
+                });
+    }
+
+    @Transactional
+    public Optional<BookResponse> patch(Long id, PatchBookRequest request) {
+        return bookRepository.findById(id)
+                .map(book -> {
+                    bookMapper.patchEntity(request, book);
+                    return bookMapper.toResponse(book);
+                });
     }
 
     public boolean deleteById(Long id) {

--- a/src/main/java/com/github/nanachi357/library/service/ReaderService.java
+++ b/src/main/java/com/github/nanachi357/library/service/ReaderService.java
@@ -1,12 +1,15 @@
 package com.github.nanachi357.library.service;
 
 import com.github.nanachi357.library.dto.CreateReaderRequest;
+import com.github.nanachi357.library.dto.PatchReaderRequest;
 import com.github.nanachi357.library.dto.ReaderResponse;
+import com.github.nanachi357.library.dto.UpdateReaderRequest;
 import com.github.nanachi357.library.entity.Reader;
 import com.github.nanachi357.library.mapper.ReaderMapper;
 import com.github.nanachi357.library.repository.ReaderRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
@@ -34,6 +37,24 @@ public class ReaderService {
         Reader savedReader = readerRepository.save(reader);
 
         return readerMapper.toResponse(savedReader);
+    }
+
+    @Transactional
+    public Optional<ReaderResponse> update(Long id, UpdateReaderRequest request) {
+        return readerRepository.findById(id)
+                .map(reader -> {
+                    readerMapper.updateEntity(request, reader);
+                    return readerMapper.toResponse(reader);
+                });
+    }
+
+    @Transactional
+    public Optional<ReaderResponse> patch(Long id, PatchReaderRequest request) {
+        return readerRepository.findById(id)
+                .map(reader -> {
+                    readerMapper.patchEntity(request, reader);
+                    return readerMapper.toResponse(reader);
+                });
     }
 
     public boolean deleteById(Long id) {


### PR DESCRIPTION
## Summary

This PR adds PUT and PATCH endpoints for authors, books, and readers.

## Changes

- added request DTOs for update and patch operations
- added MapStruct methods for updating existing entities
- added transactional service methods for update and patch operations
- added PUT and PATCH endpoints to controllers

## Behavior

- PUT performs full resource updates
- PATCH performs partial updates
- PATCH ignores null fields and preserves existing entity values
- missing resources return 404 Not Found
- invalid request bodies return 400 Bad Request

## Verification

- `./gradlew clean compileJava` passes
- PostgreSQL container starts successfully
- Spring Boot application starts successfully on port 8080
- HTTP smoke tests passed: 20/20

Smoke-tested scenarios included:

- create/update/patch books
- create/update/patch readers
- create/update/patch authors
- 404 for missing resources
- 400 for invalid request bodies
- PATCH with null field preserving the existing value