### PR TITLE
feat: add pagination for collection endpoints

### DIFF
--- a/src/main/java/com/github/nanachi357/library/controller/AuthorController.java
+++ b/src/main/java/com/github/nanachi357/library/controller/AuthorController.java
@@ -3,11 +3,15 @@ package com.github.nanachi357.library.controller;
 import com.github.nanachi357.library.dto.AuthorResponse;
 import com.github.nanachi357.library.dto.BookResponse;
 import com.github.nanachi357.library.dto.CreateAuthorRequest;
+import com.github.nanachi357.library.dto.PageResponse;
 import com.github.nanachi357.library.dto.PatchAuthorRequest;
 import com.github.nanachi357.library.dto.UpdateAuthorRequest;
 import com.github.nanachi357.library.service.AuthorService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -18,10 +22,9 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.List;
 
 @RestController
 @RequestMapping("/authors")
@@ -31,8 +34,13 @@ public class AuthorController {
     private final AuthorService authorService;
 
     @GetMapping
-    public List<AuthorResponse> getAll() {
-        return authorService.getAll();
+    public PageResponse<AuthorResponse> getAll(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by("name").ascending());
+
+        return authorService.getAll(pageable);
     }
 
     @GetMapping("/{id}")
@@ -43,8 +51,14 @@ public class AuthorController {
     }
 
     @GetMapping("/{authorId}/books")
-    public ResponseEntity<List<BookResponse>> getBooksByAuthor(@PathVariable Long authorId) {
-        return ResponseEntity.ok(authorService.getBooksByAuthor(authorId));
+    public ResponseEntity<PageResponse<BookResponse>> getBooksByAuthor(
+            @PathVariable Long authorId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by("title").ascending());
+
+        return ResponseEntity.ok(authorService.getBooksByAuthor(authorId, pageable));
     }
 
     @PostMapping

--- a/src/main/java/com/github/nanachi357/library/controller/BookController.java
+++ b/src/main/java/com/github/nanachi357/library/controller/BookController.java
@@ -2,11 +2,15 @@ package com.github.nanachi357.library.controller;
 
 import com.github.nanachi357.library.dto.BookResponse;
 import com.github.nanachi357.library.dto.CreateBookRequest;
+import com.github.nanachi357.library.dto.PageResponse;
 import com.github.nanachi357.library.dto.PatchBookRequest;
 import com.github.nanachi357.library.dto.UpdateBookRequest;
 import com.github.nanachi357.library.service.BookService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -17,10 +21,9 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.List;
 
 @RestController
 @RequestMapping("/books")
@@ -30,8 +33,13 @@ public class BookController {
     private final BookService bookService;
 
     @GetMapping
-    public List<BookResponse> getAll() {
-        return bookService.getAll();
+    public PageResponse<BookResponse> getAll(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by("title").ascending());
+
+        return bookService.getAll(pageable);
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/com/github/nanachi357/library/controller/ReaderController.java
+++ b/src/main/java/com/github/nanachi357/library/controller/ReaderController.java
@@ -2,12 +2,16 @@ package com.github.nanachi357.library.controller;
 
 import com.github.nanachi357.library.dto.BookResponse;
 import com.github.nanachi357.library.dto.CreateReaderRequest;
+import com.github.nanachi357.library.dto.PageResponse;
 import com.github.nanachi357.library.dto.PatchReaderRequest;
 import com.github.nanachi357.library.dto.ReaderResponse;
 import com.github.nanachi357.library.dto.UpdateReaderRequest;
 import com.github.nanachi357.library.service.ReaderService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -18,10 +22,9 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.List;
 
 @RestController
 @RequestMapping("/readers")
@@ -31,8 +34,13 @@ public class ReaderController {
     private final ReaderService readerService;
 
     @GetMapping
-    public List<ReaderResponse> getAll() {
-        return readerService.getAll();
+    public PageResponse<ReaderResponse> getAll(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by("name").ascending());
+
+        return readerService.getAll(pageable);
     }
 
     @GetMapping("/{id}")
@@ -43,8 +51,14 @@ public class ReaderController {
     }
 
     @GetMapping("/{readerId}/books")
-    public ResponseEntity<List<BookResponse>> getBooksByReader(@PathVariable Long readerId) {
-        return ResponseEntity.ok(readerService.getBooksByReader(readerId));
+    public ResponseEntity<PageResponse<BookResponse>> getBooksByReader(
+            @PathVariable Long readerId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by("title").ascending());
+
+        return ResponseEntity.ok(readerService.getBooksByReader(readerId, pageable));
     }
 
     @PostMapping

--- a/src/main/java/com/github/nanachi357/library/dto/PageResponse.java
+++ b/src/main/java/com/github/nanachi357/library/dto/PageResponse.java
@@ -1,0 +1,28 @@
+package com.github.nanachi357.library.dto;
+
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+public record PageResponse<T>(
+        List<T> content,
+        int page,
+        int size,
+        long totalElements,
+        int totalPages,
+        boolean first,
+        boolean last
+) {
+
+    public static <T> PageResponse<T> from(Page<T> page) {
+        return new PageResponse<>(
+                page.getContent(),
+                page.getNumber(),
+                page.getSize(),
+                page.getTotalElements(),
+                page.getTotalPages(),
+                page.isFirst(),
+                page.isLast()
+        );
+    }
+}

--- a/src/main/java/com/github/nanachi357/library/repository/BookRepository.java
+++ b/src/main/java/com/github/nanachi357/library/repository/BookRepository.java
@@ -1,11 +1,11 @@
 package com.github.nanachi357.library.repository;
 
 import com.github.nanachi357.library.entity.Book;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-
-import java.util.List;
 
 public interface BookRepository extends JpaRepository<Book, Long> {
 
@@ -14,12 +14,12 @@ public interface BookRepository extends JpaRepository<Book, Long> {
             join b.authors a
             where a.id = :authorId
             """)
-    List<Book> findAllByAuthorId(@Param("authorId") Long authorId);
+    Page<Book> findAllByAuthorId(@Param("authorId") Long authorId, Pageable pageable);
 
     @Query("""
             select b from Book b
             join b.readers r
             where r.id = :readerId
             """)
-    List<Book> findAllByReaderId(@Param("readerId") Long readerId);
+    Page<Book> findAllByReaderId(@Param("readerId") Long readerId, Pageable pageable);
 }

--- a/src/main/java/com/github/nanachi357/library/service/AuthorService.java
+++ b/src/main/java/com/github/nanachi357/library/service/AuthorService.java
@@ -3,6 +3,7 @@ package com.github.nanachi357.library.service;
 import com.github.nanachi357.library.dto.AuthorResponse;
 import com.github.nanachi357.library.dto.BookResponse;
 import com.github.nanachi357.library.dto.CreateAuthorRequest;
+import com.github.nanachi357.library.dto.PageResponse;
 import com.github.nanachi357.library.dto.PatchAuthorRequest;
 import com.github.nanachi357.library.dto.UpdateAuthorRequest;
 import com.github.nanachi357.library.entity.Author;
@@ -12,11 +13,11 @@ import com.github.nanachi357.library.mapper.BookMapper;
 import com.github.nanachi357.library.repository.AuthorRepository;
 import com.github.nanachi357.library.repository.BookRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.HashSet;
-import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -29,10 +30,11 @@ public class AuthorService {
     private final BookMapper bookMapper;
     private final BookRelationService bookRelationService;
 
-    public List<AuthorResponse> getAll() {
-        return authorRepository.findAll().stream()
-                .map(authorMapper::toResponse)
-                .toList();
+    public PageResponse<AuthorResponse> getAll(Pageable pageable) {
+        var authors = authorRepository.findAll(pageable)
+                .map(authorMapper::toResponse);
+
+        return PageResponse.from(authors);
     }
 
     public Optional<AuthorResponse> getById(Long id) {
@@ -66,14 +68,15 @@ public class AuthorService {
     }
 
     @Transactional(readOnly = true)
-    public List<BookResponse> getBooksByAuthor(Long authorId) {
+    public PageResponse<BookResponse> getBooksByAuthor(Long authorId, Pageable pageable) {
         if (!authorRepository.existsById(authorId)) {
             throw new ResourceNotFoundException("Author not found with id: " + authorId);
         }
 
-        return bookRepository.findAllByAuthorId(authorId).stream()
-                .map(bookMapper::toResponse)
-                .toList();
+        var books = bookRepository.findAllByAuthorId(authorId, pageable)
+                .map(bookMapper::toResponse);
+
+        return PageResponse.from(books);
     }
 
     @Transactional

--- a/src/main/java/com/github/nanachi357/library/service/BookService.java
+++ b/src/main/java/com/github/nanachi357/library/service/BookService.java
@@ -2,6 +2,7 @@ package com.github.nanachi357.library.service;
 
 import com.github.nanachi357.library.dto.BookResponse;
 import com.github.nanachi357.library.dto.CreateBookRequest;
+import com.github.nanachi357.library.dto.PageResponse;
 import com.github.nanachi357.library.dto.PatchBookRequest;
 import com.github.nanachi357.library.dto.UpdateBookRequest;
 import com.github.nanachi357.library.entity.Author;
@@ -13,10 +14,10 @@ import com.github.nanachi357.library.repository.AuthorRepository;
 import com.github.nanachi357.library.repository.BookRepository;
 import com.github.nanachi357.library.repository.ReaderRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -29,10 +30,11 @@ public class BookService {
     private final BookMapper bookMapper;
     private final BookRelationService bookRelationService;
 
-    public List<BookResponse> getAll() {
-        return bookRepository.findAll().stream()
-                .map(bookMapper::toResponse)
-                .toList();
+    public PageResponse<BookResponse> getAll(Pageable pageable) {
+        var books = bookRepository.findAll(pageable)
+                .map(bookMapper::toResponse);
+
+        return PageResponse.from(books);
     }
 
     public Optional<BookResponse> getById(Long id) {

--- a/src/main/java/com/github/nanachi357/library/service/ReaderService.java
+++ b/src/main/java/com/github/nanachi357/library/service/ReaderService.java
@@ -2,6 +2,7 @@ package com.github.nanachi357.library.service;
 
 import com.github.nanachi357.library.dto.BookResponse;
 import com.github.nanachi357.library.dto.CreateReaderRequest;
+import com.github.nanachi357.library.dto.PageResponse;
 import com.github.nanachi357.library.dto.PatchReaderRequest;
 import com.github.nanachi357.library.dto.ReaderResponse;
 import com.github.nanachi357.library.dto.UpdateReaderRequest;
@@ -12,11 +13,11 @@ import com.github.nanachi357.library.mapper.ReaderMapper;
 import com.github.nanachi357.library.repository.BookRepository;
 import com.github.nanachi357.library.repository.ReaderRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.HashSet;
-import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -29,10 +30,11 @@ public class ReaderService {
     private final BookMapper bookMapper;
     private final BookRelationService bookRelationService;
 
-    public List<ReaderResponse> getAll() {
-        return readerRepository.findAll().stream()
-                .map(readerMapper::toResponse)
-                .toList();
+    public PageResponse<ReaderResponse> getAll(Pageable pageable) {
+        var readers = readerRepository.findAll(pageable)
+                .map(readerMapper::toResponse);
+
+        return PageResponse.from(readers);
     }
 
     public Optional<ReaderResponse> getById(Long id) {
@@ -66,14 +68,15 @@ public class ReaderService {
     }
 
     @Transactional(readOnly = true)
-    public List<BookResponse> getBooksByReader(Long readerId) {
+    public PageResponse<BookResponse> getBooksByReader(Long readerId, Pageable pageable) {
         if (!readerRepository.existsById(readerId)) {
             throw new ResourceNotFoundException("Reader not found with id: " + readerId);
         }
 
-        return bookRepository.findAllByReaderId(readerId).stream()
-                .map(bookMapper::toResponse)
-                .toList();
+        var books = bookRepository.findAllByReaderId(readerId, pageable)
+                .map(bookMapper::toResponse);
+
+        return PageResponse.from(books);
     }
 
     @Transactional


### PR DESCRIPTION
## Summary

Added pagination for collection endpoints:

* `GET /books`
* `GET /authors`
* `GET /readers`
* `GET /authors/{authorId}/books`
* `GET /readers/{readerId}/books`

The endpoints now return a custom `PageResponse<T>` with page metadata instead of a raw list.

Default alphabetical sorting is applied:

* books by `title`
* authors by `name`
* readers by `name`
* books by author/reader by `title`

Custom sorting is not included in this task.

## Verification

* compile check passed
* checked pagination with different `page` / `size` values
* checked default alphabetical sorting
* checked books by author/reader pagination
* checked missing author/reader cases still return `404`
* checked single-resource endpoints still return regular DTO responses
