### PR TITLE
feat: add actuator monitoring endpoints

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,6 +19,7 @@ repositories {
 }
 
 dependencies {
+    implementation("org.springframework.boot:spring-boot-starter-actuator")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springframework.boot:spring-boot-starter-web")

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,3 +8,9 @@ spring.datasource.driver-class-name=org.postgresql.Driver
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
+
+management.endpoints.web.exposure.include=health,info,metrics
+management.info.env.enabled=true
+
+info.app.name=library
+info.app.description=Library Spring Boot application


### PR DESCRIPTION
## Summary

Added basic Spring Boot Actuator support.

Exposed safe monitoring endpoints:

* `/actuator/health`
* `/actuator/info`
* `/actuator/metrics`

Added minimal application metadata for `/actuator/info`.

Sensitive endpoints such as `env`, `shutdown`, `loggers`, `heapdump`, `threaddump`, `beans`, `mappings`, and `prometheus` are not exposed.

## Verification

* compile check passed
* application starts successfully
* `/actuator` exposes only the expected links
* `/actuator/health` returns `UP`
* `/actuator/info` returns configured app metadata
* `/actuator/metrics` returns available metric names
* checked several real metric endpoints
* checked sensitive actuator endpoints are not exposed
* existing `/books`, `/authors`, and `/readers` endpoints still work
