### PR TITLE
test: add unit and integration tests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,8 +33,9 @@ dependencies {
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.springframework.boot:spring-boot-starter-webmvc-test")
-    testImplementation("org.testcontainers:junit-jupiter:1.21.4")
-    testImplementation("org.testcontainers:postgresql:1.21.4")
+    testImplementation(platform("org.testcontainers:testcontainers-bom:2.0.4"))
+    testImplementation("org.testcontainers:testcontainers-junit-jupiter")
+    testImplementation("org.testcontainers:testcontainers-postgresql")
     testCompileOnly("org.projectlombok:lombok")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
     testAnnotationProcessor("org.projectlombok:lombok")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,6 +32,9 @@ dependencies {
     annotationProcessor("org.mapstruct:mapstruct-processor:1.6.3")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("org.springframework.boot:spring-boot-starter-webmvc-test")
+    testImplementation("org.testcontainers:junit-jupiter:1.21.4")
+    testImplementation("org.testcontainers:postgresql:1.21.4")
     testCompileOnly("org.projectlombok:lombok")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
     testAnnotationProcessor("org.projectlombok:lombok")

--- a/src/test/java/com/github/nanachi357/library/controller/BookEndpointIntegrationTest.java
+++ b/src/test/java/com/github/nanachi357/library/controller/BookEndpointIntegrationTest.java
@@ -15,9 +15,10 @@ import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
-import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.postgresql.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
 
 import java.time.LocalDate;
 
@@ -34,8 +35,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @Testcontainers
 class BookEndpointIntegrationTest {
 
+    private static final DockerImageName POSTGRES_IMAGE = DockerImageName.parse("postgres:16-alpine");
+
     @Container
-    private static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>("postgres:16-alpine")
+    private static final PostgreSQLContainer POSTGRES = new PostgreSQLContainer(POSTGRES_IMAGE)
             .withDatabaseName("library_test")
             .withUsername("postgres")
             .withPassword("postgres");

--- a/src/test/java/com/github/nanachi357/library/controller/BookEndpointIntegrationTest.java
+++ b/src/test/java/com/github/nanachi357/library/controller/BookEndpointIntegrationTest.java
@@ -1,0 +1,208 @@
+package com.github.nanachi357.library.controller;
+
+import com.github.nanachi357.library.entity.Author;
+import com.github.nanachi357.library.entity.Book;
+import com.github.nanachi357.library.entity.Reader;
+import com.github.nanachi357.library.repository.AuthorRepository;
+import com.github.nanachi357.library.repository.BookRepository;
+import com.github.nanachi357.library.repository.ReaderRepository;
+import com.github.nanachi357.library.service.BookRelationService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.time.LocalDate;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.not;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers
+class BookEndpointIntegrationTest {
+
+    @Container
+    private static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>("postgres:16-alpine")
+            .withDatabaseName("library_test")
+            .withUsername("postgres")
+            .withPassword("postgres");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private BookRepository bookRepository;
+
+    @Autowired
+    private AuthorRepository authorRepository;
+
+    @Autowired
+    private ReaderRepository readerRepository;
+
+    @Autowired
+    private BookRelationService bookRelationService;
+
+    @DynamicPropertySource
+    static void configureDatasource(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", POSTGRES::getJdbcUrl);
+        registry.add("spring.datasource.username", POSTGRES::getUsername);
+        registry.add("spring.datasource.password", POSTGRES::getPassword);
+        registry.add("spring.jpa.hibernate.ddl-auto", () -> "create");
+    }
+
+    @BeforeEach
+    void cleanDatabase() {
+        bookRepository.deleteAll();
+        authorRepository.deleteAll();
+        readerRepository.deleteAll();
+    }
+
+    @Test
+    void getBooks_returnsPagedResponseSortedByTitleAsc() throws Exception {
+        bookRepository.save(new Book("Refactoring"));
+        bookRepository.save(new Book("Clean Code"));
+        bookRepository.save(new Book("Domain-Driven Design"));
+
+        mockMvc.perform(get("/books")
+                        .param("page", "0")
+                        .param("size", "2"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content.length()").value(2))
+                .andExpect(jsonPath("$.content[0].title").value("Clean Code"))
+                .andExpect(jsonPath("$.content[1].title").value("Domain-Driven Design"))
+                .andExpect(jsonPath("$.page").value(0))
+                .andExpect(jsonPath("$.size").value(2))
+                .andExpect(jsonPath("$.totalElements").value(3))
+                .andExpect(jsonPath("$.totalPages").value(2))
+                .andExpect(jsonPath("$.first").value(true))
+                .andExpect(jsonPath("$.last").value(false));
+    }
+
+    @Test
+    void getBooks_ignoresSortQueryParameter() throws Exception {
+        bookRepository.save(new Book("Refactoring"));
+        bookRepository.save(new Book("Clean Code"));
+        bookRepository.save(new Book("Domain-Driven Design"));
+
+        mockMvc.perform(get("/books")
+                        .param("page", "0")
+                        .param("size", "10")
+                        .param("sort", "id,desc"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content.length()").value(3))
+                .andExpect(jsonPath("$.content[0].title").value("Clean Code"))
+                .andExpect(jsonPath("$.content[1].title").value("Domain-Driven Design"))
+                .andExpect(jsonPath("$.content[2].title").value("Refactoring"))
+                .andExpect(jsonPath("$.page").value(0))
+                .andExpect(jsonPath("$.size").value(10))
+                .andExpect(jsonPath("$.totalElements").value(3))
+                .andExpect(jsonPath("$.totalPages").value(1))
+                .andExpect(jsonPath("$.first").value(true))
+                .andExpect(jsonPath("$.last").value(true));
+    }
+
+    @Test
+    void getBooksByAuthor_returnsOnlyLinkedBooksPagedAndSorted() throws Exception {
+        Author targetAuthor = authorRepository.save(author("Target Author"));
+        Author unrelatedAuthor = authorRepository.save(author("Unrelated Author"));
+        Book cleanCode = bookRepository.save(new Book("Clean Code"));
+        Book refactoring = bookRepository.save(new Book("Refactoring"));
+        Book domainDrivenDesign = bookRepository.save(new Book("Domain-Driven Design"));
+        Book unrelatedBook = bookRepository.save(new Book("Algorithms"));
+
+        bookRelationService.addAuthorToBook(cleanCode, targetAuthor);
+        bookRelationService.addAuthorToBook(refactoring, targetAuthor);
+        bookRelationService.addAuthorToBook(domainDrivenDesign, targetAuthor);
+        bookRelationService.addAuthorToBook(unrelatedBook, unrelatedAuthor);
+        bookRepository.save(cleanCode);
+        bookRepository.save(refactoring);
+        bookRepository.save(domainDrivenDesign);
+        bookRepository.save(unrelatedBook);
+
+        mockMvc.perform(get("/authors/{authorId}/books", targetAuthor.getId())
+                        .param("page", "0")
+                        .param("size", "2"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content.length()").value(2))
+                .andExpect(jsonPath("$.content[0].title").value("Clean Code"))
+                .andExpect(jsonPath("$.content[1].title").value("Domain-Driven Design"))
+                .andExpect(jsonPath("$.content[*].title").value(contains("Clean Code", "Domain-Driven Design")))
+                .andExpect(jsonPath("$.content[*].title").value(not(hasItem("Algorithms"))))
+                .andExpect(jsonPath("$.page").value(0))
+                .andExpect(jsonPath("$.size").value(2))
+                .andExpect(jsonPath("$.totalElements").value(3))
+                .andExpect(jsonPath("$.totalPages").value(2))
+                .andExpect(jsonPath("$.first").value(true))
+                .andExpect(jsonPath("$.last").value(false));
+    }
+
+    @Test
+    void getBooksByReader_returnsOnlyLinkedBooksPagedAndSorted() throws Exception {
+        Reader targetReader = readerRepository.save(new Reader("Target Reader"));
+        Reader unrelatedReader = readerRepository.save(new Reader("Unrelated Reader"));
+        Book cleanCode = bookRepository.save(new Book("Clean Code"));
+        Book refactoring = bookRepository.save(new Book("Refactoring"));
+        Book domainDrivenDesign = bookRepository.save(new Book("Domain-Driven Design"));
+        Book unrelatedBook = bookRepository.save(new Book("Algorithms"));
+
+        bookRelationService.addReaderToBook(cleanCode, targetReader);
+        bookRelationService.addReaderToBook(refactoring, targetReader);
+        bookRelationService.addReaderToBook(domainDrivenDesign, targetReader);
+        bookRelationService.addReaderToBook(unrelatedBook, unrelatedReader);
+        bookRepository.save(cleanCode);
+        bookRepository.save(refactoring);
+        bookRepository.save(domainDrivenDesign);
+        bookRepository.save(unrelatedBook);
+
+        mockMvc.perform(get("/readers/{readerId}/books", targetReader.getId())
+                        .param("page", "0")
+                        .param("size", "2"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content.length()").value(2))
+                .andExpect(jsonPath("$.content[0].title").value("Clean Code"))
+                .andExpect(jsonPath("$.content[1].title").value("Domain-Driven Design"))
+                .andExpect(jsonPath("$.content[*].title").value(contains("Clean Code", "Domain-Driven Design")))
+                .andExpect(jsonPath("$.content[*].title").value(not(hasItem("Algorithms"))))
+                .andExpect(jsonPath("$.page").value(0))
+                .andExpect(jsonPath("$.size").value(2))
+                .andExpect(jsonPath("$.totalElements").value(3))
+                .andExpect(jsonPath("$.totalPages").value(2))
+                .andExpect(jsonPath("$.first").value(true))
+                .andExpect(jsonPath("$.last").value(false));
+    }
+
+    @Test
+    void getBooksByMissingAuthor_returnsNotFound() throws Exception {
+        mockMvc.perform(get("/authors/{authorId}/books", 999999L)
+                        .param("page", "0")
+                        .param("size", "2"))
+                .andExpect(status().isNotFound())
+                .andExpect(content().string(""));
+    }
+
+    @Test
+    void getBooksByMissingReader_returnsNotFound() throws Exception {
+        mockMvc.perform(get("/readers/{readerId}/books", 999999L)
+                        .param("page", "0")
+                        .param("size", "2"))
+                .andExpect(status().isNotFound())
+                .andExpect(content().string(""));
+    }
+
+    private static Author author(String name) {
+        return new Author(name, LocalDate.of(1970, 1, 1), "Ukraine");
+    }
+}

--- a/src/test/java/com/github/nanachi357/library/service/AuthorServiceTest.java
+++ b/src/test/java/com/github/nanachi357/library/service/AuthorServiceTest.java
@@ -1,0 +1,176 @@
+package com.github.nanachi357.library.service;
+
+import com.github.nanachi357.library.dto.AuthorResponse;
+import com.github.nanachi357.library.dto.BookResponse;
+import com.github.nanachi357.library.dto.PageResponse;
+import com.github.nanachi357.library.entity.Author;
+import com.github.nanachi357.library.entity.Book;
+import com.github.nanachi357.library.exception.ResourceNotFoundException;
+import com.github.nanachi357.library.mapper.AuthorMapper;
+import com.github.nanachi357.library.mapper.BookMapper;
+import com.github.nanachi357.library.repository.AuthorRepository;
+import com.github.nanachi357.library.repository.BookRepository;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AuthorServiceTest {
+
+    @Mock
+    private AuthorRepository authorRepository;
+
+    @Mock
+    private BookRepository bookRepository;
+
+    @Mock
+    private AuthorMapper authorMapper;
+
+    @Mock
+    private BookMapper bookMapper;
+
+    @Mock
+    private BookRelationService bookRelationService;
+
+    @InjectMocks
+    private AuthorService authorService;
+
+    @Test
+    void getAll_shouldReturnPagedAuthorResponsesAndPreserveMetadata() {
+        Pageable pageable = PageRequest.of(1, 2);
+        Author firstAuthor = author("First Author");
+        Author secondAuthor = author("Second Author");
+        AuthorResponse firstResponse = response(1L, "First Author");
+        AuthorResponse secondResponse = response(2L, "Second Author");
+        when(authorRepository.findAll(pageable))
+                .thenReturn(new PageImpl<>(List.of(firstAuthor, secondAuthor), pageable, 5));
+        when(authorMapper.toResponse(firstAuthor)).thenReturn(firstResponse);
+        when(authorMapper.toResponse(secondAuthor)).thenReturn(secondResponse);
+
+        PageResponse<AuthorResponse> response = authorService.getAll(pageable);
+
+        assertThat(response.content()).containsExactly(firstResponse, secondResponse);
+        assertThat(response.page()).isEqualTo(1);
+        assertThat(response.size()).isEqualTo(2);
+        assertThat(response.totalElements()).isEqualTo(5);
+        assertThat(response.totalPages()).isEqualTo(3);
+        assertThat(response.first()).isFalse();
+        assertThat(response.last()).isFalse();
+        verify(authorRepository).findAll(pageable);
+        verify(authorMapper).toResponse(firstAuthor);
+        verify(authorMapper).toResponse(secondAuthor);
+    }
+
+    @Test
+    void getBooksByAuthor_existingAuthor_shouldReturnPagedBookResponses() {
+        Long authorId = 1L;
+        Pageable pageable = PageRequest.of(0, 2);
+        Book firstBook = new Book("Clean Code");
+        Book secondBook = new Book("Refactoring");
+        BookResponse firstResponse = new BookResponse(1L, "Clean Code");
+        BookResponse secondResponse = new BookResponse(2L, "Refactoring");
+        when(authorRepository.existsById(authorId)).thenReturn(true);
+        when(bookRepository.findAllByAuthorId(authorId, pageable))
+                .thenReturn(new PageImpl<>(List.of(firstBook, secondBook), pageable, 4));
+        when(bookMapper.toResponse(firstBook)).thenReturn(firstResponse);
+        when(bookMapper.toResponse(secondBook)).thenReturn(secondResponse);
+
+        PageResponse<BookResponse> response = authorService.getBooksByAuthor(authorId, pageable);
+
+        assertThat(response.content()).containsExactly(firstResponse, secondResponse);
+        assertThat(response.page()).isZero();
+        assertThat(response.size()).isEqualTo(2);
+        assertThat(response.totalElements()).isEqualTo(4);
+        assertThat(response.totalPages()).isEqualTo(2);
+        assertThat(response.first()).isTrue();
+        assertThat(response.last()).isFalse();
+        verify(authorRepository).existsById(authorId);
+        verify(bookRepository).findAllByAuthorId(authorId, pageable);
+        verify(bookMapper).toResponse(firstBook);
+        verify(bookMapper).toResponse(secondBook);
+    }
+
+    @Test
+    void getBooksByAuthor_missingAuthor_shouldThrowResourceNotFoundException() {
+        Long authorId = 1L;
+        Pageable pageable = PageRequest.of(0, 2);
+        when(authorRepository.existsById(authorId)).thenReturn(false);
+
+        assertThatThrownBy(() -> authorService.getBooksByAuthor(authorId, pageable))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessage("Author not found with id: " + authorId);
+
+        verify(bookRepository, never()).findAllByAuthorId(authorId, pageable);
+    }
+
+    @Test
+    void deleteById_existingAuthor_shouldUnlinkBooksBeforeDeletingAuthor() {
+        Long authorId = 1L;
+        Author author = author("Neil Gaiman");
+        Book firstBook = new Book("Good Omens");
+        Book secondBook = new Book("Neverwhere");
+        author.getBooks().add(firstBook);
+        author.getBooks().add(secondBook);
+        List<String> events = new ArrayList<>();
+        when(authorRepository.findById(authorId)).thenReturn(Optional.of(author));
+        doAnswer(invocation -> {
+            events.add("unlink");
+            return null;
+        }).when(bookRelationService).removeAuthorFromBook(any(Book.class), same(author));
+        doAnswer(invocation -> {
+            events.add("delete");
+            return null;
+        }).when(authorRepository).delete(author);
+
+        boolean deleted = authorService.deleteById(authorId);
+
+        assertThat(deleted).isTrue();
+        ArgumentCaptor<Book> bookCaptor = ArgumentCaptor.forClass(Book.class);
+        verify(bookRelationService, times(2)).removeAuthorFromBook(bookCaptor.capture(), same(author));
+        assertThat(bookCaptor.getAllValues()).containsExactlyInAnyOrder(firstBook, secondBook);
+        verify(authorRepository).delete(author);
+        assertThat(events).containsExactly("unlink", "unlink", "delete");
+    }
+
+    @Test
+    void deleteById_missingAuthor_shouldReturnFalseAndNotDeleteAuthor() {
+        Long authorId = 1L;
+        when(authorRepository.findById(authorId)).thenReturn(Optional.empty());
+
+        boolean deleted = authorService.deleteById(authorId);
+
+        assertThat(deleted).isFalse();
+        verifyNoInteractions(bookRelationService);
+        verify(authorRepository, never()).delete(any(Author.class));
+    }
+
+    private static Author author(String name) {
+        return new Author(name, LocalDate.of(1960, 11, 10), "United Kingdom");
+    }
+
+    private static AuthorResponse response(Long id, String name) {
+        return new AuthorResponse(id, name, LocalDate.of(1960, 11, 10), "United Kingdom");
+    }
+}

--- a/src/test/java/com/github/nanachi357/library/service/BookRelationServiceTest.java
+++ b/src/test/java/com/github/nanachi357/library/service/BookRelationServiceTest.java
@@ -1,0 +1,99 @@
+package com.github.nanachi357.library.service;
+
+import com.github.nanachi357.library.entity.Author;
+import com.github.nanachi357.library.entity.Book;
+import com.github.nanachi357.library.entity.Reader;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BookRelationServiceTest {
+
+    private final BookRelationService bookRelationService = new BookRelationService();
+
+    @Test
+    void addAuthorToBook_updatesBothSides() {
+        Book book = new Book("Clean Code");
+        Author author = author();
+
+        bookRelationService.addAuthorToBook(book, author);
+
+        assertThat(book.getAuthors()).containsExactly(author);
+        assertThat(author.getBooks()).containsExactly(book);
+    }
+
+    @Test
+    void removeAuthorFromBook_updatesBothSides() {
+        Book book = new Book("Clean Code");
+        Author author = author();
+        bookRelationService.addAuthorToBook(book, author);
+
+        bookRelationService.removeAuthorFromBook(book, author);
+
+        assertThat(book.getAuthors()).doesNotContain(author);
+        assertThat(author.getBooks()).doesNotContain(book);
+    }
+
+    @Test
+    void addReaderToBook_updatesBothSides() {
+        Book book = new Book("Clean Code");
+        Reader reader = new Reader("Iryna Bondar");
+
+        bookRelationService.addReaderToBook(book, reader);
+
+        assertThat(book.getReaders()).containsExactly(reader);
+        assertThat(reader.getBooks()).containsExactly(book);
+    }
+
+    @Test
+    void removeReaderFromBook_updatesBothSides() {
+        Book book = new Book("Clean Code");
+        Reader reader = new Reader("Iryna Bondar");
+        bookRelationService.addReaderToBook(book, reader);
+
+        bookRelationService.removeReaderFromBook(book, reader);
+
+        assertThat(book.getReaders()).doesNotContain(reader);
+        assertThat(reader.getBooks()).doesNotContain(book);
+    }
+
+    @Test
+    void removeAllAuthorsFromBook_removesAllLinksFromBothSides() {
+        Book book = new Book("Clean Code");
+        Author firstAuthor = author("First Author");
+        Author secondAuthor = author("Second Author");
+        bookRelationService.addAuthorToBook(book, firstAuthor);
+        bookRelationService.addAuthorToBook(book, secondAuthor);
+
+        bookRelationService.removeAllAuthorsFromBook(book);
+
+        assertThat(book.getAuthors()).isEmpty();
+        assertThat(firstAuthor.getBooks()).doesNotContain(book);
+        assertThat(secondAuthor.getBooks()).doesNotContain(book);
+    }
+
+    @Test
+    void removeAllReadersFromBook_removesAllLinksFromBothSides() {
+        Book book = new Book("Clean Code");
+        Reader firstReader = new Reader("First Reader");
+        Reader secondReader = new Reader("Second Reader");
+        bookRelationService.addReaderToBook(book, firstReader);
+        bookRelationService.addReaderToBook(book, secondReader);
+
+        bookRelationService.removeAllReadersFromBook(book);
+
+        assertThat(book.getReaders()).isEmpty();
+        assertThat(firstReader.getBooks()).doesNotContain(book);
+        assertThat(secondReader.getBooks()).doesNotContain(book);
+    }
+
+    private static Author author() {
+        return author("Robert Martin");
+    }
+
+    private static Author author(String name) {
+        return new Author(name, LocalDate.of(1952, 12, 5), "United States");
+    }
+}

--- a/src/test/java/com/github/nanachi357/library/service/BookServiceTest.java
+++ b/src/test/java/com/github/nanachi357/library/service/BookServiceTest.java
@@ -1,0 +1,201 @@
+package com.github.nanachi357.library.service;
+
+import com.github.nanachi357.library.dto.BookResponse;
+import com.github.nanachi357.library.dto.PageResponse;
+import com.github.nanachi357.library.entity.Author;
+import com.github.nanachi357.library.entity.Book;
+import com.github.nanachi357.library.entity.Reader;
+import com.github.nanachi357.library.exception.ResourceNotFoundException;
+import com.github.nanachi357.library.mapper.BookMapper;
+import com.github.nanachi357.library.repository.AuthorRepository;
+import com.github.nanachi357.library.repository.BookRepository;
+import com.github.nanachi357.library.repository.ReaderRepository;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class BookServiceTest {
+
+    @Mock
+    private BookRepository bookRepository;
+
+    @Mock
+    private AuthorRepository authorRepository;
+
+    @Mock
+    private ReaderRepository readerRepository;
+
+    @Mock
+    private BookMapper bookMapper;
+
+    @Mock
+    private BookRelationService bookRelationService;
+
+    @InjectMocks
+    private BookService bookService;
+
+    @Test
+    void getAll_shouldReturnPagedBookResponsesAndPreserveMetadata() {
+        Pageable pageable = PageRequest.of(1, 2);
+        Book firstBook = new Book("Clean Code");
+        Book secondBook = new Book("Refactoring");
+        BookResponse firstResponse = new BookResponse(1L, "Clean Code");
+        BookResponse secondResponse = new BookResponse(2L, "Refactoring");
+        when(bookRepository.findAll(pageable))
+                .thenReturn(new PageImpl<>(List.of(firstBook, secondBook), pageable, 5));
+        when(bookMapper.toResponse(firstBook)).thenReturn(firstResponse);
+        when(bookMapper.toResponse(secondBook)).thenReturn(secondResponse);
+
+        PageResponse<BookResponse> response = bookService.getAll(pageable);
+
+        assertThat(response.content()).containsExactly(firstResponse, secondResponse);
+        assertThat(response.page()).isEqualTo(1);
+        assertThat(response.size()).isEqualTo(2);
+        assertThat(response.totalElements()).isEqualTo(5);
+        assertThat(response.totalPages()).isEqualTo(3);
+        assertThat(response.first()).isFalse();
+        assertThat(response.last()).isFalse();
+        verify(bookRepository).findAll(pageable);
+        verify(bookMapper).toResponse(firstBook);
+        verify(bookMapper).toResponse(secondBook);
+    }
+
+    @Test
+    void addAuthorToBook_existingBookAndAuthor_shouldLinkRelation() {
+        Long bookId = 1L;
+        Long authorId = 2L;
+        Book book = new Book("Good Omens");
+        Author author = author();
+        when(bookRepository.findById(bookId)).thenReturn(Optional.of(book));
+        when(authorRepository.findById(authorId)).thenReturn(Optional.of(author));
+
+        bookService.addAuthorToBook(bookId, authorId);
+
+        verify(bookRepository).findById(bookId);
+        verify(authorRepository).findById(authorId);
+        verify(bookRelationService).addAuthorToBook(book, author);
+    }
+
+    @Test
+    void addAuthorToBook_missingBook_shouldThrowResourceNotFoundException() {
+        Long bookId = 1L;
+        when(bookRepository.findById(bookId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> bookService.addAuthorToBook(bookId, 2L))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessage("Book not found with id: " + bookId);
+
+        verify(authorRepository, never()).findById(2L);
+        verifyNoInteractions(bookRelationService);
+    }
+
+    @Test
+    void addAuthorToBook_missingAuthor_shouldThrowResourceNotFoundException() {
+        Long bookId = 1L;
+        Long authorId = 2L;
+        Book book = new Book("Good Omens");
+        when(bookRepository.findById(bookId)).thenReturn(Optional.of(book));
+        when(authorRepository.findById(authorId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> bookService.addAuthorToBook(bookId, authorId))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessage("Author not found with id: " + authorId);
+
+        verifyNoInteractions(bookRelationService);
+    }
+
+    @Test
+    void addReaderToBook_existingBookAndReader_shouldLinkRelation() {
+        Long bookId = 1L;
+        Long readerId = 2L;
+        Book book = new Book("Good Omens");
+        Reader reader = new Reader("Iryna Bondar");
+        when(bookRepository.findById(bookId)).thenReturn(Optional.of(book));
+        when(readerRepository.findById(readerId)).thenReturn(Optional.of(reader));
+
+        bookService.addReaderToBook(bookId, readerId);
+
+        verify(bookRepository).findById(bookId);
+        verify(readerRepository).findById(readerId);
+        verify(bookRelationService).addReaderToBook(book, reader);
+    }
+
+    @Test
+    void addReaderToBook_missingBook_shouldThrowResourceNotFoundException() {
+        Long bookId = 1L;
+        when(bookRepository.findById(bookId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> bookService.addReaderToBook(bookId, 2L))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessage("Book not found with id: " + bookId);
+
+        verify(readerRepository, never()).findById(2L);
+        verifyNoInteractions(bookRelationService);
+    }
+
+    @Test
+    void addReaderToBook_missingReader_shouldThrowResourceNotFoundException() {
+        Long bookId = 1L;
+        Long readerId = 2L;
+        Book book = new Book("Good Omens");
+        when(bookRepository.findById(bookId)).thenReturn(Optional.of(book));
+        when(readerRepository.findById(readerId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> bookService.addReaderToBook(bookId, readerId))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessage("Reader not found with id: " + readerId);
+
+        verifyNoInteractions(bookRelationService);
+    }
+
+    @Test
+    void deleteById_existingBook_shouldUnlinkRelationsBeforeDeletingBook() {
+        Long bookId = 1L;
+        Book book = new Book("Good Omens");
+        when(bookRepository.findById(bookId)).thenReturn(Optional.of(book));
+
+        boolean deleted = bookService.deleteById(bookId);
+
+        assertThat(deleted).isTrue();
+        InOrder ordered = inOrder(bookRelationService, bookRepository);
+        ordered.verify(bookRelationService).removeAllAuthorsFromBook(book);
+        ordered.verify(bookRelationService).removeAllReadersFromBook(book);
+        ordered.verify(bookRepository).delete(book);
+    }
+
+    @Test
+    void deleteById_missingBook_shouldReturnFalseAndNotDeleteBook() {
+        Long bookId = 1L;
+        when(bookRepository.findById(bookId)).thenReturn(Optional.empty());
+
+        boolean deleted = bookService.deleteById(bookId);
+
+        assertThat(deleted).isFalse();
+        verifyNoInteractions(bookRelationService);
+        verify(bookRepository, never()).delete(any(Book.class));
+    }
+
+    private static Author author() {
+        return new Author("Neil Gaiman", LocalDate.of(1960, 11, 10), "United Kingdom");
+    }
+}

--- a/src/test/java/com/github/nanachi357/library/service/ReaderServiceTest.java
+++ b/src/test/java/com/github/nanachi357/library/service/ReaderServiceTest.java
@@ -1,0 +1,167 @@
+package com.github.nanachi357.library.service;
+
+import com.github.nanachi357.library.dto.BookResponse;
+import com.github.nanachi357.library.dto.PageResponse;
+import com.github.nanachi357.library.dto.ReaderResponse;
+import com.github.nanachi357.library.entity.Book;
+import com.github.nanachi357.library.entity.Reader;
+import com.github.nanachi357.library.exception.ResourceNotFoundException;
+import com.github.nanachi357.library.mapper.BookMapper;
+import com.github.nanachi357.library.mapper.ReaderMapper;
+import com.github.nanachi357.library.repository.BookRepository;
+import com.github.nanachi357.library.repository.ReaderRepository;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ReaderServiceTest {
+
+    @Mock
+    private ReaderRepository readerRepository;
+
+    @Mock
+    private BookRepository bookRepository;
+
+    @Mock
+    private ReaderMapper readerMapper;
+
+    @Mock
+    private BookMapper bookMapper;
+
+    @Mock
+    private BookRelationService bookRelationService;
+
+    @InjectMocks
+    private ReaderService readerService;
+
+    @Test
+    void getAll_shouldReturnPagedReaderResponsesAndPreserveMetadata() {
+        Pageable pageable = PageRequest.of(1, 2);
+        Reader firstReader = new Reader("First Reader");
+        Reader secondReader = new Reader("Second Reader");
+        ReaderResponse firstResponse = new ReaderResponse(1L, "First Reader");
+        ReaderResponse secondResponse = new ReaderResponse(2L, "Second Reader");
+        when(readerRepository.findAll(pageable))
+                .thenReturn(new PageImpl<>(List.of(firstReader, secondReader), pageable, 5));
+        when(readerMapper.toResponse(firstReader)).thenReturn(firstResponse);
+        when(readerMapper.toResponse(secondReader)).thenReturn(secondResponse);
+
+        PageResponse<ReaderResponse> response = readerService.getAll(pageable);
+
+        assertThat(response.content()).containsExactly(firstResponse, secondResponse);
+        assertThat(response.page()).isEqualTo(1);
+        assertThat(response.size()).isEqualTo(2);
+        assertThat(response.totalElements()).isEqualTo(5);
+        assertThat(response.totalPages()).isEqualTo(3);
+        assertThat(response.first()).isFalse();
+        assertThat(response.last()).isFalse();
+        verify(readerRepository).findAll(pageable);
+        verify(readerMapper).toResponse(firstReader);
+        verify(readerMapper).toResponse(secondReader);
+    }
+
+    @Test
+    void getBooksByReader_existingReader_shouldReturnPagedBookResponses() {
+        Long readerId = 1L;
+        Pageable pageable = PageRequest.of(0, 2);
+        Book firstBook = new Book("Clean Code");
+        Book secondBook = new Book("Refactoring");
+        BookResponse firstResponse = new BookResponse(1L, "Clean Code");
+        BookResponse secondResponse = new BookResponse(2L, "Refactoring");
+        when(readerRepository.existsById(readerId)).thenReturn(true);
+        when(bookRepository.findAllByReaderId(readerId, pageable))
+                .thenReturn(new PageImpl<>(List.of(firstBook, secondBook), pageable, 4));
+        when(bookMapper.toResponse(firstBook)).thenReturn(firstResponse);
+        when(bookMapper.toResponse(secondBook)).thenReturn(secondResponse);
+
+        PageResponse<BookResponse> response = readerService.getBooksByReader(readerId, pageable);
+
+        assertThat(response.content()).containsExactly(firstResponse, secondResponse);
+        assertThat(response.page()).isZero();
+        assertThat(response.size()).isEqualTo(2);
+        assertThat(response.totalElements()).isEqualTo(4);
+        assertThat(response.totalPages()).isEqualTo(2);
+        assertThat(response.first()).isTrue();
+        assertThat(response.last()).isFalse();
+        verify(readerRepository).existsById(readerId);
+        verify(bookRepository).findAllByReaderId(readerId, pageable);
+        verify(bookMapper).toResponse(firstBook);
+        verify(bookMapper).toResponse(secondBook);
+    }
+
+    @Test
+    void getBooksByReader_missingReader_shouldThrowResourceNotFoundException() {
+        Long readerId = 1L;
+        Pageable pageable = PageRequest.of(0, 2);
+        when(readerRepository.existsById(readerId)).thenReturn(false);
+
+        assertThatThrownBy(() -> readerService.getBooksByReader(readerId, pageable))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessage("Reader not found with id: " + readerId);
+
+        verify(bookRepository, never()).findAllByReaderId(readerId, pageable);
+    }
+
+    @Test
+    void deleteById_existingReader_shouldUnlinkBooksBeforeDeletingReader() {
+        Long readerId = 1L;
+        Reader reader = new Reader("Iryna Bondar");
+        Book firstBook = new Book("Good Omens");
+        Book secondBook = new Book("Neverwhere");
+        reader.getBooks().add(firstBook);
+        reader.getBooks().add(secondBook);
+        List<String> events = new ArrayList<>();
+        when(readerRepository.findById(readerId)).thenReturn(Optional.of(reader));
+        doAnswer(invocation -> {
+            events.add("unlink");
+            return null;
+        }).when(bookRelationService).removeReaderFromBook(any(Book.class), same(reader));
+        doAnswer(invocation -> {
+            events.add("delete");
+            return null;
+        }).when(readerRepository).delete(reader);
+
+        boolean deleted = readerService.deleteById(readerId);
+
+        assertThat(deleted).isTrue();
+        ArgumentCaptor<Book> bookCaptor = ArgumentCaptor.forClass(Book.class);
+        verify(bookRelationService, times(2)).removeReaderFromBook(bookCaptor.capture(), same(reader));
+        assertThat(bookCaptor.getAllValues()).containsExactlyInAnyOrder(firstBook, secondBook);
+        verify(readerRepository).delete(reader);
+        assertThat(events).containsExactly("unlink", "unlink", "delete");
+    }
+
+    @Test
+    void deleteById_missingReader_shouldReturnFalseAndNotDeleteReader() {
+        Long readerId = 1L;
+        when(readerRepository.findById(readerId)).thenReturn(Optional.empty());
+
+        boolean deleted = readerService.deleteById(readerId);
+
+        assertThat(deleted).isFalse();
+        verifyNoInteractions(bookRelationService);
+        verify(readerRepository, never()).delete(any(Reader.class));
+    }
+}


### PR DESCRIPTION
## Summary

Added service unit tests and integration tests for paginated book query endpoints.

### Unit tests

Added unit tests for:

* `BookRelationService`
* `BookService`
* `AuthorService`
* `ReaderService`

Covered service-level behavior:

* pagination metadata preservation
* mapper usage
* bidirectional relation consistency
* not-found behavior
* delete cleanup before deleting entities
* missing-resource delete behavior

### Integration tests

Added `BookEndpointIntegrationTest` using:

* Spring Boot Test
* MockMvc
* PostgreSQL Testcontainers

Covered endpoint behavior:

* `GET /books?page=0&size=2`
* fixed title ASC sorting
* ignored `sort` query parameter behavior
* `GET /authors/{authorId}/books?page=0&size=2`
* `GET /readers/{readerId}/books?page=0&size=2`
* 404 responses for missing author/reader

### Testcontainers setup

Aligned Testcontainers dependencies to 2.x using the Testcontainers BOM and updated the PostgreSQL container setup to the current Testcontainers 2.x API.

## Verification

* `.\gradlew.bat clean test --console=plain`
* All service unit tests passed
* All integration tests passed
* PostgreSQL Testcontainer started successfully
* No production code changes
* No production configuration changes
* No H2, REST-assured, Actuator, security, or full CRUD matrix tests added
